### PR TITLE
Enable consumable card effects

### DIFF
--- a/src/components/RunPhase.jsx
+++ b/src/components/RunPhase.jsx
@@ -18,6 +18,7 @@ const RunPhase = ({
   setShowStuckPopup,
   inventory,
   missionLog,
+  scannerRevealTurns,
   showMissionSummary,
   missionSummaryData,
   confirmMissionEnd
@@ -86,7 +87,9 @@ const RunPhase = ({
                   Rewards: {action.rewards.credits} credits{action.rewards.data > 0 && `, ${action.rewards.data} data`}
                   {action.rewards.scrap > 0 && `, ${action.rewards.scrap} scrap`}
                 </div>
-                <div className="text-gray-400">Success chance: {Math.floor(action.successChance * 100)}%</div>
+                <div className="text-gray-400">
+                  Success chance: {scannerRevealTurns > 0 ? (action.successChance * 100).toFixed(1) : Math.floor(action.successChance * 100)}%
+                </div>
               </div>
             </button>
           );


### PR DESCRIPTION
## Summary
- add state for temporary item effects
- allow equipping stronger items when slots are full
- reset temporary effects when starting a run
- activate effects when consuming weapon, scanner, or shield cards
- apply these effects during missions
- show precise success rates when scanners are active

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688929b2a0188320937fa4eb7e0833f2