### PR TITLE
Add persistent save and achievements

### DIFF
--- a/src/components/MenuPhase.jsx
+++ b/src/components/MenuPhase.jsx
@@ -15,7 +15,9 @@ const MenuPhase = ({
   planetsSettled,
   battlesWon,
   prestigePoints,
-  prestige
+  prestige,
+  achievements,
+  achievementDefinitions
 }) => (
   <div className="space-y-6">
     <div className="bg-gray-800 rounded-lg p-6">
@@ -84,6 +86,20 @@ const MenuPhase = ({
           <div className="text-sm text-gray-400">Battles Won</div>
         </div>
       </div>
+    </div>
+
+    <div className="bg-gray-800 rounded-lg p-6">
+      <h3 className="text-xl mb-3">Achievements</h3>
+      {achievements.length === 0 ? (
+        <div className="text-center text-gray-400">No achievements yet.</div>
+      ) : (
+        <ul className="list-disc pl-5 space-y-1 text-sm">
+          {achievements.map(id => {
+            const def = achievementDefinitions.find(a => a.id === id);
+            return <li key={id}>{def ? def.name : id}</li>;
+          })}
+        </ul>
+      )}
     </div>
 
     {prestigePoints >= 50 && (

--- a/src/utils/achievements.js
+++ b/src/utils/achievements.js
@@ -1,0 +1,22 @@
+export const achievementDefinitions = [
+  {
+    id: 'galaxy_discovered',
+    name: 'Galactic Explorer',
+    condition: state => state.galaxiesExplored > 1,
+  },
+  {
+    id: 'battle_won',
+    name: 'Battle Hardened',
+    condition: state => state.battlesWon > 0,
+  },
+  {
+    id: 'planet_settled',
+    name: 'Colonizer',
+    condition: state => state.planetsSettled > 0,
+  },
+  {
+    id: 'credits_500',
+    name: 'Wealthy Captain',
+    condition: state => state.credits >= 500,
+  },
+];


### PR DESCRIPTION
## Summary
- create achievements definitions
- load/save game state from `localStorage`
- unlock achievements when conditions are met
- display achievements in the menu phase
- export achievement data for reuse

## Testing
- `CI=true npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_688931dc0a8883209547bd37fb7702f5