### PR TITLE
Improve notification modal and clean mission summary

### DIFF
--- a/src/components/Notification.jsx
+++ b/src/components/Notification.jsx
@@ -24,12 +24,6 @@ const Notification = ({ notification, onClose }) => {
       <div
         className={`relative p-6 rounded-lg shadow-lg border-2 max-w-md w-full mx-4 ${baseClass}`}
       >
-        <button
-          onClick={onClose}
-          className="absolute top-2 right-2 text-white hover:text-gray-300"
-        >
-          <Close className="w-5 h-5" />
-        </button>
         <div className="flex items-start gap-4">
           <Icon className="w-8 h-8 flex-shrink-0" />
           <div className="flex-1">
@@ -40,9 +34,9 @@ const Notification = ({ notification, onClose }) => {
             <p className="text-sm whitespace-pre-line">{notification.message}</p>
           </div>
         </div>
-        {notification.actions && notification.actions.length > 0 && (
-          <div className="mt-4 flex justify-end gap-2">
-            {notification.actions.map((action, idx) => (
+        <div className="mt-4 flex justify-center gap-2">
+          {notification.actions && notification.actions.length > 0 &&
+            notification.actions.map((action, idx) => (
               <button
                 key={idx}
                 onClick={action.onClick}
@@ -51,8 +45,13 @@ const Notification = ({ notification, onClose }) => {
                 {action.label}
               </button>
             ))}
-          </div>
-        )}
+          <button
+            onClick={onClose}
+            className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded text-sm"
+          >
+            OK
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/RunPhase.jsx
+++ b/src/components/RunPhase.jsx
@@ -109,7 +109,7 @@ const RunPhase = ({
 
     {showMissionSummary && missionSummaryData && (
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className={`rounded-lg p-6 max-w-md mx-4 border-2 ${missionSummaryData.status === 'Success' ? 'bg-green-900 border-green-600' : missionSummaryData.status === 'Partial Success' ? 'bg-yellow-900 border-yellow-600' : 'bg-red-900 border-red-600'}`}>\
+        <div className={`rounded-lg p-6 max-w-md mx-4 border-2 ${missionSummaryData.status === 'Success' ? 'bg-green-900 border-green-600' : missionSummaryData.status === 'Partial Success' ? 'bg-yellow-900 border-yellow-600' : 'bg-red-900 border-red-600'}`}>
           <h3 className="text-2xl font-bold mb-4 text-center">
             {missionSummaryData.status === 'Success' ? '🎉 Mission Success!' : missionSummaryData.status === 'Partial Success' ? '⚠️ Partial Success' : '💥 Mission Failed'}
           </h3>


### PR DESCRIPTION
## Summary
- replace notification close icon with centered **OK** button
- remove stray character at the start of mission summary modal

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688a7c1c2580832091d4da458ece7ca3