### PR TITLE
feat: show rarity breakdown in inventory

### DIFF
--- a/src/components/InventoryPhase.jsx
+++ b/src/components/InventoryPhase.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Star } from 'lucide-react';
 import { cardTypes, rarities } from '../utils/constants';
 
+// Order to display rarity counts
+const rarityOrder = ['legendary', 'epic', 'rare', 'uncommon', 'common'];
+
 const InventoryPhase = ({
   ship,
   equippedCards,
@@ -19,25 +22,42 @@ const InventoryPhase = ({
         {previousPhase === 'run' ? 'Back to Mission' : 'Back to Menu'}
       </button>
     </div>
-
-    <div className="bg-gray-800 rounded-lg p-6">
+    <div className="bg-gray-800 rounded-lg p-6 space-y-8">
       <h3 className="text-xl mb-4">Equipment Loadout</h3>
       {Object.entries(ship.equipmentSlots).map(([slotType, maxSlots]) => {
         const equipped = equippedCards[slotType] || [];
         const SlotIcon = cardTypes[slotType]?.icon || Star;
+        const cardInfo = cardTypes[slotType];
+        const availableCards = inventory
+          .filter(card => !card.isEquipped && card.type === slotType)
+          .sort((a, b) => {
+            const order = { legendary: 5, epic: 4, rare: 3, uncommon: 2, common: 1 };
+            return order[b.rarity] - order[a.rarity];
+          });
+        const rarityCounts = availableCards.reduce((acc, card) => {
+          acc[card.rarity] = (acc[card.rarity] || 0) + 1;
+          return acc;
+        }, {});
+        const raritySummary = rarityOrder
+          .map(r => (rarityCounts[r] ? `${rarityCounts[r]} ${rarities[r].name}` : null))
+          .filter(Boolean)
+          .join(', ');
         return (
           <div key={slotType} className="mb-6">
-            <h4 className="text-lg mb-2 flex items-center gap-2">
+            <h4 className="text-lg flex items-center gap-2 mb-2">
               <SlotIcon className="w-5 h-5" />
-              {cardTypes[slotType]?.name} Slots ({equipped.length}/{maxSlots})
+              {cardInfo?.name} Slots ({equipped.length}/{maxSlots})
             </h4>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {raritySummary && (
+              <div className="text-sm text-gray-400 mb-2">Available: {raritySummary}</div>
+            )}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
               {Array.from({ length: maxSlots }).map((_, slotIndex) => {
                 const card = equipped[slotIndex];
                 return (
                   <div key={slotIndex} className="relative">
                     {card ? (
-                      <div className={`${rarities[card.rarity].color} p-3 rounded-lg text-center relative`}>
+                      <div className={`${rarities[card.rarity].color} p-3 rounded-lg text-center relative shadow-md hover:shadow-xl transform hover:scale-105 transition-transform`}>
                         <SlotIcon className="mx-auto mb-1" size={16} />
                         <div className="text-xs font-bold">{rarities[card.rarity].name}</div>
                         <div className="text-xs">{cardTypes[card.type]?.name}</div>
@@ -53,68 +73,41 @@ const InventoryPhase = ({
                 );
               })}
             </div>
+            {availableCards.length > 0 ? (
+              <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
+                {availableCards.map(card => {
+                  const canEquip = equipped.length < maxSlots;
+                  return (
+                    <div key={card.id} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative shadow-md hover:shadow-xl transform hover:scale-105 transition-transform`}>
+                      <SlotIcon className="mx-auto mb-1" size={16} />
+                      <div className="font-bold">{rarities[card.rarity].name}</div>
+                      <div>{cardInfo?.name}</div>
+                      <div className="mt-1">
+                        <div>Equip: +{card.equipPower}</div>
+                        <div>Use: +{card.consumePower}</div>
+                      </div>
+                      <div className="mt-2 space-y-1">
+                        {canEquip ? (
+                          <button onClick={() => equipCard(card.id)} className="w-full bg-blue-600 hover:bg-blue-700 text-white text-xs px-2 py-1 rounded">Equip</button>
+                        ) : (
+                          <div className="text-xs text-gray-400 mb-1">Slots full</div>
+                        )}
+                        <button onClick={() => consumeCard(card.id)} className="w-full bg-green-600 hover:bg-green-700 text-white text-xs px-2 py-1 rounded">Use</button>
+                      </div>
+                      <div className="text-xs mt-1 text-gray-200">
+                        <div>⚙️ {cardInfo?.equipEffect}</div>
+                        <div>💊 {cardInfo?.consumeEffect}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="text-center text-gray-400 text-sm">No available cards</div>
+            )}
           </div>
         );
       })}
-    </div>
-
-    <div className="bg-gray-800 rounded-lg p-6">
-      <h3 className="text-xl mb-4">Available Cards ({inventory.filter(c => !c.isEquipped).length})</h3>
-      {inventory.filter(c => !c.isEquipped).length === 0 ? (
-        <div className="text-center text-gray-400 py-8">No cards available. Open some card packs!</div>
-      ) : (
-        <div className="space-y-6 max-h-96 overflow-y-auto">
-          {Object.entries(cardTypes).map(([cardType, cardInfo]) => {
-            const cardsOfType = inventory
-              .filter(card => !card.isEquipped && card.type === cardType)
-              .sort((a, b) => {
-                const rarityOrder = { legendary: 5, epic: 4, rare: 3, uncommon: 2, common: 1 };
-                return rarityOrder[b.rarity] - rarityOrder[a.rarity];
-              });
-            if (cardsOfType.length === 0) return null;
-            const CardIcon = cardInfo.icon || Star;
-            const equippedOfType = equippedCards[cardType] || [];
-            const maxSlots = ship.equipmentSlots[cardType] || 0;
-            return (
-              <div key={cardType} className="border-t border-gray-700 pt-4 first:border-t-0 first:pt-0">
-                <h4 className="text-lg mb-3 flex items-center gap-2">
-                  <CardIcon className="w-5 h-5" />
-                  {cardInfo.name}s ({cardsOfType.length})
-                  <span className="text-sm text-gray-400">- {equippedOfType.length}/{maxSlots} equipped</span>
-                </h4>
-                <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
-                  {cardsOfType.map(card => {
-                    const canEquip = equippedOfType.length < maxSlots;
-                    return (
-                      <div key={card.id} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative`}>
-                        <CardIcon className="mx-auto mb-1" size={16} />
-                        <div className="font-bold">{rarities[card.rarity].name}</div>
-                        <div>{cardInfo.name}</div>
-                        <div className="mt-1">
-                          <div>Equip: +{card.equipPower}</div>
-                          <div>Use: +{card.consumePower}</div>
-                        </div>
-                        <div className="mt-2 space-y-1">
-                          {canEquip ? (
-                            <button onClick={() => equipCard(card.id)} className="w-full bg-blue-600 hover:bg-blue-700 text-white text-xs px-2 py-1 rounded">Equip</button>
-                          ) : (
-                            <div className="text-xs text-gray-400 mb-1">Slots full</div>
-                          )}
-                          <button onClick={() => consumeCard(card.id)} className="w-full bg-green-600 hover:bg-green-700 text-white text-xs px-2 py-1 rounded">Use</button>
-                        </div>
-                        <div className="text-xs mt-1 text-gray-200">
-                          <div>⚙️ {cardInfo.equipEffect}</div>
-                          <div>💊 {cardInfo.consumeEffect}</div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
     </div>
   </div>
 );


### PR DESCRIPTION
## Summary
- integrate equipment slots with matching card inventory
- highlight cards with hover effects and show per-slot rarity counts

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bdbad73ac8320929035f391bad991