### PR TITLE
Revamp layout to display more mission data

### DIFF
--- a/src/components/MenuPhase.jsx
+++ b/src/components/MenuPhase.jsx
@@ -42,7 +42,7 @@ const MenuPhase = ({
       </div>
     </div>
 
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       <div className="bg-gray-800 rounded-lg p-6">
         <h3 className="text-xl mb-3">Ship Status</h3>
         <div className="space-y-2">
@@ -70,38 +70,38 @@ const MenuPhase = ({
           <div>🏛️ Settler: Level {skills.settler}</div>
         </div>
       </div>
-    </div>
 
-    <div className="bg-gray-800 rounded-lg p-6">
-      <h3 className="text-xl mb-3">Career Statistics</h3>
-      <div className="grid grid-cols-3 gap-4 text-center">
-        <div>
-          <div className="text-2xl">{galaxiesExplored}</div>
-          <div className="text-sm text-gray-400">Galaxies Explored</div>
-        </div>
-        <div>
-          <div className="text-2xl">{planetsSettled}</div>
-          <div className="text-sm text-gray-400">Planets Settled</div>
-        </div>
-        <div>
-          <div className="text-2xl">{battlesWon}</div>
-          <div className="text-sm text-gray-400">Battles Won</div>
+      <div className="bg-gray-800 rounded-lg p-6">
+        <h3 className="text-xl mb-3">Career Statistics</h3>
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-2xl">{galaxiesExplored}</div>
+            <div className="text-sm text-gray-400">Galaxies Explored</div>
+          </div>
+          <div>
+            <div className="text-2xl">{planetsSettled}</div>
+            <div className="text-sm text-gray-400">Planets Settled</div>
+          </div>
+          <div>
+            <div className="text-2xl">{battlesWon}</div>
+            <div className="text-sm text-gray-400">Battles Won</div>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div className="bg-gray-800 rounded-lg p-6">
-      <h3 className="text-xl mb-3">Achievements</h3>
-      {achievements.length === 0 ? (
-        <div className="text-center text-gray-400">No achievements yet.</div>
-      ) : (
-        <ul className="list-disc pl-5 space-y-1 text-sm">
-          {achievements.map(id => {
-            const def = achievementDefinitions.find(a => a.id === id);
-            return <li key={id}>{def ? def.name : id}</li>;
-          })}
-        </ul>
-      )}
+      <div className="bg-gray-800 rounded-lg p-6">
+        <h3 className="text-xl mb-3">Achievements</h3>
+        {achievements.length === 0 ? (
+          <div className="text-center text-gray-400">No achievements yet.</div>
+        ) : (
+          <ul className="list-disc pl-5 space-y-1 text-sm">
+            {achievements.map(id => {
+              const def = achievementDefinitions.find(a => a.id === id);
+              return <li key={id}>{def ? def.name : id}</li>;
+            })}
+          </ul>
+        )}
+      </div>
     </div>
 
     {prestigePoints >= 50 && (

--- a/src/components/RunPhase.jsx
+++ b/src/components/RunPhase.jsx
@@ -22,117 +22,120 @@ const RunPhase = ({
   ship,
   equipmentBonuses
 }) => (
-  <div className="space-y-6">
-    <div className="bg-gray-800 rounded-lg p-6">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-2xl">Mission #{runNumber} - Turn {turn}</h2>
-        <button onClick={endRun} className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg">
-          End Mission
-        </button>
+  <div className="space-y-6 md:space-y-0 md:grid md:grid-cols-3 md:gap-6">
+    <div className="space-y-6 md:col-span-1">
+      <div className="bg-gray-800 rounded-lg p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl">Mission #{runNumber} - Turn {turn}</h2>
+          <button onClick={endRun} className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg">
+            End Mission
+          </button>
+        </div>
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Fuel className="w-4 h-4 text-orange-400" />
+              <span>Fuel: {fuel}/{maxFuel}</span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2">
+              <div className="bg-orange-400 h-2 rounded-full transition-all duration-300" style={{ width: `${(fuel / maxFuel) * 100}%` }}></div>
+            </div>
+          </div>
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Apple className="w-4 h-4 text-green-400" />
+              <span>Food: {food}/{maxFood}</span>
+            </div>
+            <div className="w-full bg-gray-700 rounded-full h-2">
+              <div className="bg-green-400 h-2 rounded-full transition-all duration-300" style={{ width: `${(food / maxFood) * 100}%` }}></div>
+            </div>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 text-sm">
+          <div>
+            <h3 className="text-lg mb-1">Ship Stats</h3>
+            <div className="space-y-1">
+              <div><span className="font-bold">{ship.name}</span> (Level {ship.level})</div>
+              <div>Fuel Efficiency: {ship.fuelEfficiency}</div>
+              <div>Weapons: {ship.weapons}</div>
+              <div>Cargo: {ship.cargo}</div>
+            </div>
+          </div>
+          <div>
+            <h3 className="text-lg mb-1">Bonuses</h3>
+            <div className="space-y-1">
+              <div>Fuel Cost Reduction: {equipmentBonuses.fuelCostReduction}</div>
+              <div>
+                Food Cost Reduction (E/F/S): {equipmentBonuses.foodCostReduction.explorer}/{equipmentBonuses.foodCostReduction.fighter}/{equipmentBonuses.foodCostReduction.settler}
+              </div>
+              <div>
+                Success Bonus (E/F/S): {equipmentBonuses.successBonus.explorer}/{equipmentBonuses.successBonus.fighter}/{equipmentBonuses.successBonus.settler}
+              </div>
+              <div>
+                Reward Bonus (E/F/S): {equipmentBonuses.rewardBonus.explorer}/{equipmentBonuses.rewardBonus.fighter}/{equipmentBonuses.rewardBonus.settler}
+              </div>
+              <div>Failure Penalty Reduction: {equipmentBonuses.failurePenaltyReduction}</div>
+            </div>
+          </div>
+        </div>
       </div>
-      <div className="grid grid-cols-2 gap-4 mb-4">
-        <div>
-          <div className="flex items-center gap-2 mb-1">
-            <Fuel className="w-4 h-4 text-orange-400" />
-            <span>Fuel: {fuel}/{maxFuel}</span>
-          </div>
-          <div className="w-full bg-gray-700 rounded-full h-2">
-            <div className="bg-orange-400 h-2 rounded-full transition-all duration-300" style={{ width: `${(fuel / maxFuel) * 100}%` }}></div>
-          </div>
-        </div>
-        <div>
-          <div className="flex items-center gap-2 mb-1">
-            <Apple className="w-4 h-4 text-green-400" />
-            <span>Food: {food}/{maxFood}</span>
-          </div>
-          <div className="w-full bg-gray-700 rounded-full h-2">
-            <div className="bg-green-400 h-2 rounded-full transition-all duration-300" style={{ width: `${(food / maxFood) * 100}%` }}></div>
-          </div>
-        </div>
-      </div>
-      <div className="grid md:grid-cols-2 gap-4 mt-4 text-sm">
-        <div>
-          <h3 className="text-lg mb-1">Ship Stats</h3>
-          <div className="space-y-1">
-            <div><span className="font-bold">{ship.name}</span> (Level {ship.level})</div>
-            <div>Fuel Efficiency: {ship.fuelEfficiency}</div>
-            <div>Weapons: {ship.weapons}</div>
-            <div>Cargo: {ship.cargo}</div>
-          </div>
-        </div>
-        <div>
-          <h3 className="text-lg mb-1">Bonuses</h3>
-          <div className="space-y-1">
-            <div>Fuel Cost Reduction: {equipmentBonuses.fuelCostReduction}</div>
-            <div>
-              Food Cost Reduction (E/F/S): {equipmentBonuses.foodCostReduction.explorer}/{equipmentBonuses.foodCostReduction.fighter}/{equipmentBonuses.foodCostReduction.settler}
+
+      <div className="bg-gray-800 rounded-lg p-4">
+        <h3 className="text-lg mb-2">Mission Log</h3>
+        <div id="mission-log" className="space-y-1 text-sm max-h-64 overflow-y-auto">
+          {missionLog.map((log, index) => (
+            <div key={index} className="text-gray-300">
+              {log}
             </div>
-            <div>
-              Success Bonus (E/F/S): {equipmentBonuses.successBonus.explorer}/{equipmentBonuses.successBonus.fighter}/{equipmentBonuses.successBonus.settler}
-            </div>
-            <div>
-              Reward Bonus (E/F/S): {equipmentBonuses.rewardBonus.explorer}/{equipmentBonuses.rewardBonus.fighter}/{equipmentBonuses.rewardBonus.settler}
-            </div>
-            <div>Failure Penalty Reduction: {equipmentBonuses.failurePenaltyReduction}</div>
-          </div>
+          ))}
         </div>
       </div>
     </div>
 
-    <div className="bg-gray-800 rounded-lg p-6">
-      <div className="flex justify-between items-center mb-4">
-        <h3 className="text-xl">Choose Your Action</h3>
-        <button onClick={() => goToInventory('run')} className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm">
-          🎒 Use Items
-        </button>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {currentActions.map(action => {
-          const canAfford = fuel >= action.costs.fuel && food >= action.costs.food && scrap >= action.costs.scrap;
-          const risk = riskLevels[action.risk];
-          const skillIcons = { explorer: Search, fighter: Sword, settler: Globe };
-          const ActionIcon = skillIcons[action.skillType];
-          return (
-            <button
-              key={action.id}
-              onClick={() => takeAction(action)}
-              disabled={!canAfford}
-              className={`p-4 rounded-lg transition-colors text-left ${canAfford ? 'bg-gray-700 hover:bg-gray-600 border-2 border-gray-600 hover:border-gray-500' : 'bg-gray-800 border-2 border-gray-700 opacity-50 cursor-not-allowed'}`}
-            >
-              <div className="flex items-center gap-2 mb-2">
-                <ActionIcon className="w-5 h-5" />
-                <span className="font-bold text-lg">{action.template.name}</span>
-                <span className={`text-sm ${risk.color} ml-auto`}>({risk.name})</span>
-              </div>
-              <div className="text-sm text-gray-300 mb-3">{action.template.description}</div>
-              <div className="text-xs space-y-1">
-                <div className="text-red-300">
-                  Costs: {action.costs.fuel} fuel, {action.costs.food} food{action.costs.scrap > 0 && `, ${action.costs.scrap} scrap`}
+    <div className="md:col-span-2 space-y-6">
+      <div className="bg-gray-800 rounded-lg p-6 h-full">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-xl">Choose Your Action</h3>
+          <button onClick={() => goToInventory('run')} className="bg-orange-600 hover:bg-orange-700 px-3 py-1 rounded text-sm">
+            🎒 Use Items
+          </button>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {currentActions.map(action => {
+            const canAfford = fuel >= action.costs.fuel && food >= action.costs.food && scrap >= action.costs.scrap;
+            const risk = riskLevels[action.risk];
+            const skillIcons = { explorer: Search, fighter: Sword, settler: Globe };
+            const ActionIcon = skillIcons[action.skillType];
+            return (
+              <button
+                key={action.id}
+                onClick={() => takeAction(action)}
+                disabled={!canAfford}
+                className={`p-4 rounded-lg transition-colors text-left ${canAfford ? 'bg-gray-700 hover:bg-gray-600 border-2 border-gray-600 hover:border-gray-500' : 'bg-gray-800 border-2 border-gray-700 opacity-50 cursor-not-allowed'}`}
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <ActionIcon className="w-5 h-5" />
+                  <span className="font-bold text-lg">{action.template.name}</span>
+                  <span className={`text-sm ${risk.color} ml-auto`}>({risk.name})</span>
                 </div>
-                <div className="text-green-300">
-                  Rewards: {action.rewards.credits} credits{action.rewards.data > 0 && `, ${action.rewards.data} data`}
-                  {action.rewards.scrap > 0 && `, ${action.rewards.scrap} scrap`}
+                <div className="text-sm text-gray-300 mb-3">{action.template.description}</div>
+                <div className="text-xs space-y-1">
+                  <div className="text-red-300">
+                    Costs: {action.costs.fuel} fuel, {action.costs.food} food{action.costs.scrap > 0 && `, ${action.costs.scrap} scrap`}
+                  </div>
+                  <div className="text-green-300">
+                    Rewards: {action.rewards.credits} credits{action.rewards.data > 0 && `, ${action.rewards.data} data`}
+                    {action.rewards.scrap > 0 && `, ${action.rewards.scrap} scrap`}
+                  </div>
+                  <div className="text-gray-400">
+                    Success chance: {scannerRevealTurns > 0 ? (action.successChance * 100).toFixed(1) : Math.floor(action.successChance * 100)}%
+                  </div>
                 </div>
-                <div className="text-gray-400">
-                  Success chance: {scannerRevealTurns > 0 ? (action.successChance * 100).toFixed(1) : Math.floor(action.successChance * 100)}%
-                </div>
-              </div>
-            </button>
-          );
-        })}
-      </div>
-      {currentActions.length === 0 && <div className="text-center text-gray-400 py-8">Generating new opportunities...</div>}
-    </div>
-
-
-    <div className="bg-gray-800 rounded-lg p-4">
-      <h3 className="text-lg mb-2">Mission Log</h3>
-      <div id="mission-log" className="space-y-1 text-sm max-h-32 overflow-y-auto">
-        {missionLog.map((log, index) => (
-          <div key={index} className="text-gray-300">
-            {log}
-          </div>
-        ))}
+              </button>
+            );
+          })}
+        </div>
+        {currentActions.length === 0 && <div className="text-center text-gray-400 py-8">Generating new opportunities...</div>}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Overhaul run phase into a three-column layout with mission stats, log, and actions visible simultaneously
- Restructure menu phase into a responsive grid to show ship status, skills, career stats, and achievements at a glance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be9eb19bc832088529092339fd759