### PR TITLE
Display ship stats and bonuses side by side

### DIFF
--- a/src/components/RunPhase.jsx
+++ b/src/components/RunPhase.jsx
@@ -51,8 +51,8 @@ const RunPhase = ({
             </div>
           </div>
         </div>
-        <div className="grid grid-cols-1 gap-3 text-sm">
-          <div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+          <div className="bg-gray-700 rounded p-3">
             <h3 className="text-lg mb-1">Ship Stats</h3>
             <div className="space-y-1">
               <div><span className="font-bold">{ship.name}</span> (Level {ship.level})</div>
@@ -61,7 +61,7 @@ const RunPhase = ({
               <div>Cargo: {ship.cargo}</div>
             </div>
           </div>
-          <div>
+          <div className="bg-gray-700 rounded p-3">
             <h3 className="text-lg mb-1">Bonuses</h3>
             <div className="space-y-1">
               <div>Fuel Cost Reduction: {equipmentBonuses.fuelCostReduction}</div>


### PR DESCRIPTION
## Summary
- show ship stats and bonuses as individual cards
- place the cards side by side on mission screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688beeb26bb083209479333f3b9bb635