### PR TITLE
Add PropTypes and tests for component reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "postcss-normalize": "^10.0.1",
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
+        "prop-types": "^15.8.1",
         "react": "^19.1.1",
         "react-app-polyfill": "^3.0.0",
         "react-dev-utils": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^7.0.1",
     "prompts": "^2.4.2",
+    "prop-types": "^15.8.1",
     "react": "^19.1.1",
     "react-app-polyfill": "^3.0.0",
     "react-dev-utils": "^12.0.1",

--- a/src/components/MenuPhase.jsx
+++ b/src/components/MenuPhase.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Package, RotateCcw } from 'lucide-react';
 
 const MenuPhase = ({
@@ -116,3 +117,54 @@ const MenuPhase = ({
 );
 
 export default MenuPhase;
+
+MenuPhase.propTypes = {
+  runNumber: PropTypes.number.isRequired,
+  startRun: PropTypes.func.isRequired,
+  setGamePhase: PropTypes.func.isRequired,
+  goToInventory: PropTypes.func.isRequired,
+  inventory: PropTypes.array.isRequired,
+  missionHistory: PropTypes.array.isRequired,
+  ship: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    level: PropTypes.number.isRequired,
+    fuelEfficiency: PropTypes.number.isRequired,
+    weapons: PropTypes.number.isRequired,
+    cargo: PropTypes.number.isRequired,
+    equipmentSlots: PropTypes.shape({
+      weapon: PropTypes.number,
+      scanner: PropTypes.number,
+      engine: PropTypes.number,
+      habitat: PropTypes.number,
+      shield: PropTypes.number,
+      drone: PropTypes.number,
+      medkit: PropTypes.number
+    }).isRequired
+  }).isRequired,
+  equippedCards: PropTypes.shape({
+    weapon: PropTypes.object,
+    scanner: PropTypes.object,
+    engine: PropTypes.object,
+    habitat: PropTypes.object,
+    shield: PropTypes.object,
+    drone: PropTypes.object,
+    medkit: PropTypes.object
+  }).isRequired,
+  skills: PropTypes.shape({
+    explorer: PropTypes.number,
+    fighter: PropTypes.number,
+    settler: PropTypes.number
+  }).isRequired,
+  galaxiesExplored: PropTypes.number.isRequired,
+  planetsSettled: PropTypes.number.isRequired,
+  battlesWon: PropTypes.number.isRequired,
+  prestigePoints: PropTypes.number.isRequired,
+  prestige: PropTypes.func.isRequired,
+  achievements: PropTypes.array.isRequired,
+  achievementDefinitions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string
+    })
+  ).isRequired
+};

--- a/src/components/Notification.jsx
+++ b/src/components/Notification.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { CheckCircle, XCircle, Info, X as Close } from 'lucide-react';
 
 const Notification = ({ notification, onClose }) => {
@@ -58,3 +59,20 @@ const Notification = ({ notification, onClose }) => {
 };
 
 export default Notification;
+
+Notification.propTypes = {
+  notification: PropTypes.shape({
+    type: PropTypes.oneOf(['success', 'error', 'info']),
+    title: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired,
+    count: PropTypes.number,
+    icon: PropTypes.elementType,
+    actions: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        onClick: PropTypes.func.isRequired
+      })
+    )
+  }),
+  onClose: PropTypes.func.isRequired
+};

--- a/src/components/Notification.test.jsx
+++ b/src/components/Notification.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Notification from './Notification';
+
+describe('Notification component', () => {
+  it('renders notification content and triggers onClose', () => {
+    const handleClose = jest.fn();
+    const notification = {
+      type: 'success',
+      title: 'Mission Complete',
+      message: 'All objectives achieved'
+    };
+    render(<Notification notification={notification} onClose={handleClose} />);
+    expect(screen.getByText('Mission Complete')).toBeInTheDocument();
+    expect(screen.getByText('All objectives achieved')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('OK'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('returns null when notification is not provided', () => {
+    const { container } = render(<Notification notification={null} onClose={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `prop-types` dependency and use PropTypes in MenuPhase and Notification components
- introduce unit tests for Notification component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688bf3ea08d08320a471d54ee05174cf