### PR TITLE
Group identical inventory cards with quantity label

### DIFF
--- a/src/components/InventoryPhase.jsx
+++ b/src/components/InventoryPhase.jsx
@@ -34,6 +34,15 @@ const InventoryPhase = ({
             const order = { legendary: 5, epic: 4, rare: 3, uncommon: 2, common: 1 };
             return order[b.rarity] - order[a.rarity];
           });
+        const groupedCards = Object.values(
+          availableCards.reduce((acc, card) => {
+            const key = `${card.type}-${card.rarity}-${card.equipPower}-${card.consumePower}`;
+            if (!acc[key]) acc[key] = { ...card, ids: [], count: 0 };
+            acc[key].ids.push(card.id);
+            acc[key].count++;
+            return acc;
+          }, {})
+        );
         const rarityCounts = availableCards.reduce((acc, card) => {
           acc[card.rarity] = (acc[card.rarity] || 0) + 1;
           return acc;
@@ -61,7 +70,7 @@ const InventoryPhase = ({
                         <SlotIcon className="mx-auto mb-1" size={16} />
                         <div className="text-xs font-bold">{rarities[card.rarity].name}</div>
                         <div className="text-xs">{cardTypes[card.type]?.name}</div>
-                        <div className="text-xs mt-1">+{card.equipPower}</div>
+                        <div className="text-xs mt-1">⚙️+{card.equipPower}</div>
                         <button onClick={() => unequipCard(card.id)} className="absolute top-1 right-1 bg-red-600 hover:bg-red-700 text-white text-xs px-1 py-0.5 rounded">✕</button>
                       </div>
                     ) : (
@@ -73,31 +82,31 @@ const InventoryPhase = ({
                 );
               })}
             </div>
-            {availableCards.length > 0 ? (
+            {groupedCards.length > 0 ? (
               <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-3">
-                {availableCards.map(card => {
+                {groupedCards.map(card => {
                   const canEquip = equipped.length < maxSlots;
+                  const id = card.ids[0];
                   return (
-                    <div key={card.id} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative shadow-md hover:shadow-xl transform hover:scale-105 transition-transform`}>
+                    <div key={id} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative shadow-md hover:shadow-xl transform hover:scale-105 transition-transform`}>
                       <SlotIcon className="mx-auto mb-1" size={16} />
                       <div className="font-bold">{rarities[card.rarity].name}</div>
                       <div>{cardInfo?.name}</div>
-                      <div className="mt-1">
-                        <div>Equip: +{card.equipPower}</div>
-                        <div>Use: +{card.consumePower}</div>
+                      <div className="mt-1 flex justify-center gap-2">
+                        <div>⚙️+{card.equipPower}</div>
+                        <div>💊+{card.consumePower}</div>
                       </div>
                       <div className="mt-2 space-y-1">
                         {canEquip ? (
-                          <button onClick={() => equipCard(card.id)} className="w-full bg-blue-600 hover:bg-blue-700 text-white text-xs px-2 py-1 rounded">Equip</button>
+                          <button onClick={() => equipCard(id)} className="w-full bg-blue-600 hover:bg-blue-700 text-white text-xs px-2 py-1 rounded">Equip</button>
                         ) : (
                           <div className="text-xs text-gray-400 mb-1">Slots full</div>
                         )}
-                        <button onClick={() => consumeCard(card.id)} className="w-full bg-green-600 hover:bg-green-700 text-white text-xs px-2 py-1 rounded">Use</button>
+                        <button onClick={() => consumeCard(id)} className="w-full bg-green-600 hover:bg-green-700 text-white text-xs px-2 py-1 rounded">Use</button>
                       </div>
-                      <div className="text-xs mt-1 text-gray-200">
-                        <div>⚙️ {cardInfo?.equipEffect}</div>
-                        <div>💊 {cardInfo?.consumeEffect}</div>
-                      </div>
+                      {card.count > 1 && (
+                        <div className="absolute top-1 left-1 bg-gray-900 text-white text-xs px-1 py-0.5 rounded">x{card.count}</div>
+                      )}
                     </div>
                   );
                 })}

--- a/src/components/PacksPhase.jsx
+++ b/src/components/PacksPhase.jsx
@@ -2,43 +2,60 @@ import React from 'react';
 import { Star } from 'lucide-react';
 import { cardTypes, rarities } from '../utils/constants';
 
-const PacksPhase = ({ inventory, credits, setGamePhase, openPack }) => (
-  <div className="space-y-6">
-    <div className="flex justify-between items-center">
-      <h2 className="text-2xl">Card Packs</h2>
-      <button onClick={() => setGamePhase('menu')} className="bg-gray-600 hover:bg-gray-700 px-4 py-2 rounded-lg">
-        Back to Menu
-      </button>
-    </div>
-    <div className="bg-gray-800 rounded-lg p-6 text-center">
-      <div className="text-6xl mb-4">📦</div>
-      <h3 className="text-xl mb-4">Standard Pack</h3>
-      <p className="mb-4">5 random cards - 50 Credits</p>
-      <button onClick={openPack} disabled={credits < 50} className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 px-6 py-3 rounded-lg text-lg transition-colors">
-        Open Pack
-      </button>
-    </div>
-    <div className="bg-gray-800 rounded-lg p-6">
-      <h3 className="text-xl mb-4">Recent Cards ({inventory.length})</h3>
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2 max-h-60 overflow-y-auto">
-        {inventory.slice(-20).map(card => {
-          const CardIcon = cardTypes[card.type]?.icon || Star;
-          return (
-            <div key={card.id} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative`}>
-              <CardIcon className="mx-auto mb-1" size={16} />
-              <div className="font-bold">{rarities[card.rarity].name}</div>
-              <div>{cardTypes[card.type]?.name}</div>
-              <div className="mt-1">
-                <div>Equip: +{card.equipPower}</div>
-                <div>Use: +{card.consumePower}</div>
+const PacksPhase = ({ inventory, credits, setGamePhase, openPack }) => {
+  const recent = inventory.slice(-20);
+  const grouped = Object.values(
+    recent.reduce((acc, card) => {
+      const key = `${card.type}-${card.rarity}-${card.equipPower}-${card.consumePower}-${card.isEquipped}`;
+      if (!acc[key]) acc[key] = { ...card, count: 0 };
+      acc[key].count++;
+      return acc;
+    }, {})
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h2 className="text-2xl">Card Packs</h2>
+        <button onClick={() => setGamePhase('menu')} className="bg-gray-600 hover:bg-gray-700 px-4 py-2 rounded-lg">
+          Back to Menu
+        </button>
+      </div>
+      <div className="bg-gray-800 rounded-lg p-6 text-center">
+        <div className="text-6xl mb-4">📦</div>
+        <h3 className="text-xl mb-4">Standard Pack</h3>
+        <p className="mb-4">5 random cards - 50 Credits</p>
+        <button onClick={openPack} disabled={credits < 50} className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 px-6 py-3 rounded-lg text-lg transition-colors">
+          Open Pack
+        </button>
+      </div>
+      <div className="bg-gray-800 rounded-lg p-6">
+        <h3 className="text-xl mb-4">Recent Cards ({inventory.length})</h3>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-2 max-h-60 overflow-y-auto">
+          {grouped.map(card => {
+            const CardIcon = cardTypes[card.type]?.icon || Star;
+            return (
+              <div key={`${card.type}-${card.rarity}-${card.equipPower}-${card.consumePower}-${card.count}`} className={`${rarities[card.rarity].color} p-3 rounded-lg text-center text-xs relative`}>
+                <CardIcon className="mx-auto mb-1" size={16} />
+                <div className="font-bold">{rarities[card.rarity].name}</div>
+                <div>{cardTypes[card.type]?.name}</div>
+                <div className="mt-1 flex justify-center gap-2">
+                  <div>⚙️+{card.equipPower}</div>
+                  <div>💊+{card.consumePower}</div>
+                </div>
+                {card.count > 1 && (
+                  <div className="absolute top-1 left-1 bg-gray-900 text-white text-xs px-1 py-0.5 rounded">x{card.count}</div>
+                )}
+                {card.isEquipped && (
+                  <div className="absolute top-1 right-1 bg-blue-600 text-white text-xs px-1 py-0.5 rounded">⚙️</div>
+                )}
               </div>
-              {card.isEquipped && <div className="absolute top-1 right-1 bg-blue-600 text-white text-xs px-1 py-0.5 rounded">⚙️</div>}
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default PacksPhase;


### PR DESCRIPTION
## Summary
- simplify card display to show concise stats
- group duplicate inventory cards and show quantity badge
- group recent cards in pack view with compact text

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bfcd6cb9c8320a26812c2214ae56e