### PR TITLE
Clarify card effect descriptions

### DIFF
--- a/src/components/InventoryPhase.jsx
+++ b/src/components/InventoryPhase.jsx
@@ -70,7 +70,7 @@ const InventoryPhase = ({
                         <SlotIcon className="mx-auto mb-1" size={16} />
                         <div className="text-xs font-bold">{rarities[card.rarity].name}</div>
                         <div className="text-xs">{cardTypes[card.type]?.name}</div>
-                        <div className="text-xs mt-1">⚙️+{card.equipPower}</div>
+                        <div className="text-xs mt-1 text-left">⚙️ {cardInfo?.equipEffect} (+{card.equipPower})</div>
                         <button onClick={() => unequipCard(card.id)} className="absolute top-1 right-1 bg-red-600 hover:bg-red-700 text-white text-xs px-1 py-0.5 rounded">✕</button>
                       </div>
                     ) : (
@@ -92,9 +92,9 @@ const InventoryPhase = ({
                       <SlotIcon className="mx-auto mb-1" size={16} />
                       <div className="font-bold">{rarities[card.rarity].name}</div>
                       <div>{cardInfo?.name}</div>
-                      <div className="mt-1 flex justify-center gap-2">
-                        <div>⚙️+{card.equipPower}</div>
-                        <div>💊+{card.consumePower}</div>
+                      <div className="mt-1 text-left">
+                        <div>⚙️ {cardInfo?.equipEffect} (+{card.equipPower})</div>
+                        <div>💊 {cardInfo?.consumeEffect} (+{card.consumePower})</div>
                       </div>
                       <div className="mt-2 space-y-1">
                         {canEquip ? (

--- a/src/components/PacksPhase.jsx
+++ b/src/components/PacksPhase.jsx
@@ -39,9 +39,9 @@ const PacksPhase = ({ inventory, credits, setGamePhase, openPack }) => {
                 <CardIcon className="mx-auto mb-1" size={16} />
                 <div className="font-bold">{rarities[card.rarity].name}</div>
                 <div>{cardTypes[card.type]?.name}</div>
-                <div className="mt-1 flex justify-center gap-2">
-                  <div>⚙️+{card.equipPower}</div>
-                  <div>💊+{card.consumePower}</div>
+                <div className="mt-1 text-left">
+                  <div>⚙️ {cardTypes[card.type]?.equipEffect} (+{card.equipPower})</div>
+                  <div>💊 {cardTypes[card.type]?.consumeEffect} (+{card.consumePower})</div>
                 </div>
                 {card.count > 1 && (
                   <div className="absolute top-1 left-1 bg-gray-900 text-white text-xs px-1 py-0.5 rounded">x{card.count}</div>


### PR DESCRIPTION
## Summary
- clarify equip card slot text to show effect and power
- expand inventory and pack card text with detailed equip/consume effects

## Testing
- `npm test` *(fails: Cannot find module 'react-dev-utils/getPublicUrlOrPath')*

------
https://chatgpt.com/codex/tasks/task_e_688bfefbd4748320899da48dee203268